### PR TITLE
netlify: add config file (for #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ __A gulp-based starter for Static Site Generators, preconfigured for @11ty/eleve
 * 🛋 Preconfigured for [Forestry CMS](https://forestry.io/).
   * Sign up, log in, look for the `Deploy admin` option.
   * Everything else is set up for you already. :)
+* 🚀 Preconfigured for [Netlify](https://netlify.com/).
+  * Sign up, log in, add a `New site`.
+  * Out of the box staging builds include Forestry drafts and production builds do not
 * 💁Indie publishing and reading experience
   * microformats2 support for `h-card`, `h-entry`, and `h-feed` out of the box
 * 👩‍💻 Modern JavaScript

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  publish = "dist/"
+  command = "npm run prod"
+
+[build.environment]
+  NODE_ENV = "production"
+  ELEVENTY_ENV = "staging"
+
+[context.production.environment]
+  ELEVENTY_ENV = "production" # excludes Forestry drafts from production build


### PR DESCRIPTION
Resolves #26 

Adds the following Netlify config:

1. build command is `npm run prod`
2. directory to publish is `dist/`
3. staging environment variables are
    ```
    NODE_ENV = "production"
    ELEVENTY_ENV = "staging"
    ```
4. production environment variables are
    ```
    NODE_ENV = "production"
    ELEVENTY_ENV = "production"
    ```

In addition to adding out-of-the-box support for Netlify this file is clarify summary of the build command and the roles of the env var, something which wasn't immediately clear to me.

Also added Netlify to the selling points in the README. Your calling out "preconfigured for Forestry.io" is a big part of what inspired me to try this out when I picked a few 11ty starters to experiment with, and I can imagine Netlify might catch someone else's eye. The 🚀 doesn't really fit the rest of your emoji, won't be surprised if you want to change it!